### PR TITLE
feat(typebot): documentar MEGA_CMD, placeholders de listas y asignación de agentes/equipos

### DIFF
--- a/typebot-agentbot/agent-bot-typebot.es.md
+++ b/typebot-agentbot/agent-bot-typebot.es.md
@@ -33,6 +33,8 @@ Se envían solo en la primera solicitud de una sesión:
 - Contacto: `contact_name`, `contact_email`, `contact_phone`, `contact_id`, `contact_labels`, `contact_attributes`, `contact_custom_attribute_<key>`
 - Conversación: `conversation_labels`, `conversation_id`, `conversation_display_id`, `conversation_attributes`, `custom_attribute_<key>`
 - Cuenta: `account_id`
+- Agentes: `agents_json` (array JSON con id, name, availability_status), `agents_formatted` (lista numerada con emoji de disponibilidad, ej: `1. 🟢 Juan`)
+- Equipos: `teams_json` (array JSON con id y name), `teams_formatted` (lista numerada, ej: `1. Ventas`)
 
 Los valores de `<key>` se sanitizan a snake_case en minúsculas.
 
@@ -58,3 +60,71 @@ Los valores de `<key>` se sanitizan a snake_case en minúsculas.
 - Asegúrese de que `public_name` coincida con el slug público publicado en Typebot y que `api_token` esté configurado para bots privados.
 - Para los disparadores por palabra clave, confirme que tanto `trigger_operator` como `trigger_value` están configurados.
 - Si las respuestas se detienen a mitad del flujo, revise `additional_attributes.typebot` en la conversación en busca de un `session_id` obsoleto y considere usar la palabra clave de finalización o volver a abrir/cerrar la conversación para reiniciarla.
+
+## MEGA_CMD — Intercepción local de comandos
+
+Dado que un servidor Typebot externo generalmente no puede hacer llamadas HTTP de vuelta a la instancia de Mega (firewalls, aislamiento de red Docker, etc.), MEGA_CMD proporciona una forma de ejecutar acciones localmente sin webhooks.
+
+### Cómo funciona
+
+1. En tu flujo de Typebot, incluye una **burbuja de texto** con un marcador de comando: `[MEGA_CMD:acción:valor]`
+2. Cuando Mega recibe la respuesta de Typebot, intercepta el marcador **antes** de enviar el mensaje a la conversación.
+3. El comando se ejecuta del lado del servidor (ej: asignar un agente o equipo).
+4. El marcador se elimina del texto — el usuario final nunca lo ve.
+
+### Acciones soportadas
+
+| Acción | Valor | Ejemplo | Descripción |
+|--------|-------|---------|-------------|
+| `assign_agent` | ID del agente | `[MEGA_CMD:assign_agent:5]` | Asigna el agente con id 5 a la conversación |
+| `assign_team` | ID del equipo | `[MEGA_CMD:assign_team:3]` | Asigna el equipo con id 3 a la conversación |
+
+### Ejemplo en un flujo de Typebot
+
+Una burbuja de texto en Typebot puede contener:
+
+```text
+¡Gracias! Serás conectado con nuestro equipo de soporte en breve.
+[MEGA_CMD:assign_team:3]
+```
+
+El usuario ve solo: *"¡Gracias! Serás conectado con nuestro equipo de soporte en breve."*
+
+El comando puede combinarse con texto regular. También se soportan múltiples comandos en el mismo mensaje.
+
+## Placeholders de listas — Menús numerados dinámicos
+
+La interpolación de variables de Typebot puede ser poco confiable al construir listas numeradas para WhatsApp (no soporta botones). Mega provee **placeholders de listas** del lado del servidor que se reemplazan con listas numeradas generadas dinámicamente antes de entregar el mensaje.
+
+### Placeholders disponibles
+
+| Placeholder | Se reemplaza con |
+|-------------|-----------------|
+| `[TEAMS_LIST]` | Lista numerada de todos los equipos de la cuenta, ordenados por nombre. Ejemplo: `1. Ventas\n2. Soporte` |
+| `[AGENTS_LIST]` | Lista numerada de agentes en línea con emoji de disponibilidad. Ejemplo: `1. 🟢 Juan\n2. 🟢 María` |
+
+### Cómo usar en un flujo de Typebot
+
+En una burbuja de texto, incluye el placeholder:
+
+```text
+Por favor selecciona un equipo:
+
+[TEAMS_LIST]
+
+0. ⬅️ Volver al menú
+```
+
+Mega reemplaza `[TEAMS_LIST]` con la lista numerada real antes de entregar el mensaje.
+
+### Escape de listas Markdown
+
+Las listas numeradas (ej: `1. Ventas`) normalmente serían parseadas como listas ordenadas por el renderizador Markdown del dashboard, lo que renumera los ítems (ej: convirtiendo `0.` en `3.`). Mega inserta un espacio de ancho cero (U+200B) entre el dígito-punto y el espacio para evitar esto, manteniendo la numeración original tanto en WhatsApp como en el dashboard.
+
+## Acceso API con token de bot
+
+Para soportar las variables prellenadas con datos de agentes y equipos, los siguientes endpoints de la API son accesibles con tokens de bot:
+
+- `GET /api/v1/accounts/:id/agents` — Listar agentes
+- `GET /api/v1/accounts/:id/teams` — Listar equipos
+- `GET /api/v1/accounts/:id/contacts` — Listar/crear/actualizar contactos

--- a/typebot-agentbot/agent-bot-typebot.md
+++ b/typebot-agentbot/agent-bot-typebot.md
@@ -33,6 +33,8 @@ Sent only on the first request of a session:
 - Contact: `contact_name`, `contact_email`, `contact_phone`, `contact_id`, `contact_labels`, `contact_attributes`, `contact_custom_attribute_<key>`
 - Conversation: `conversation_labels`, `conversation_id`, `conversation_display_id`, `conversation_attributes`, `custom_attribute_<key>`
 - Account: `account_id`
+- Agents: `agents_json` (JSON array with id, name, availability_status), `agents_formatted` (numbered list with availability emoji, e.g., `1. 🟢 John`)
+- Teams: `teams_json` (JSON array with id and name), `teams_formatted` (numbered list, e.g., `1. Sales`)
 
 `<key>` values are sanitized to lowercase snake_case.
 
@@ -58,3 +60,71 @@ Sent only on the first request of a session:
 - Ensure `public_name` matches the Typebot publish slug and `api_token` is set for private bots.
 - For keyword triggers, confirm both `trigger_operator` and `trigger_value` are configured.
 - If responses stop mid-flow, check `additional_attributes.typebot` on the conversation for a stale `session_id` and consider using the finish keyword or reopening/closing the conversation to reset.
+
+## MEGA_CMD — Local command interception
+
+Since an external Typebot server often cannot make HTTP calls back to the Mega instance (firewalls, Docker network isolation, etc.), MEGA_CMD provides a way to execute actions locally without webhooks.
+
+### How it works
+
+1. In your Typebot flow, include a **text bubble** with a command marker: `[MEGA_CMD:action:value]`
+2. When Mega receives the Typebot response, it intercepts the marker **before** sending the message to the conversation.
+3. The command is executed server-side (e.g., assign an agent or team).
+4. The marker is stripped from the text — the end user never sees it.
+
+### Supported actions
+
+| Action | Value | Example | Description |
+|--------|-------|---------|-------------|
+| `assign_agent` | Agent ID | `[MEGA_CMD:assign_agent:5]` | Assigns agent with id 5 to the conversation |
+| `assign_team` | Team ID | `[MEGA_CMD:assign_team:3]` | Assigns team with id 3 to the conversation |
+
+### Example in a Typebot flow
+
+A text bubble in Typebot might contain:
+
+```
+Thank you! You will be connected to our support team shortly.
+[MEGA_CMD:assign_team:3]
+```
+
+The user sees only: *"Thank you! You will be connected to our support team shortly."*
+
+The command can be combined with regular text. Multiple commands in the same message are also supported.
+
+## List placeholders — Dynamic numbered menus
+
+Typebot's variable interpolation can be unreliable when building numbered lists for WhatsApp (no button support). Mega provides server-side **list placeholders** that are replaced with dynamically generated, numbered lists before the message is delivered.
+
+### Available placeholders
+
+| Placeholder | Replaced with |
+|-------------|---------------|
+| `[TEAMS_LIST]` | Numbered list of all teams in the account, ordered by name. Example: `1. Sales\n2. Support` |
+| `[AGENTS_LIST]` | Numbered list of online agents with availability emoji. Example: `1. 🟢 John\n2. 🟢 Maria` |
+
+### How to use in a Typebot flow
+
+In a text bubble, include the placeholder:
+
+```
+Please select a team:
+
+[TEAMS_LIST]
+
+0. ⬅️ Back to menu
+```
+
+Mega replaces `[TEAMS_LIST]` with the actual numbered list before delivering the message.
+
+### Markdown list escaping
+
+Numbered lists (e.g., `1. Sales`) would normally be parsed as ordered lists by the dashboard's Markdown renderer, which renumbers items (e.g., turning `0.` into `3.`). Mega inserts a zero-width space (U+200B) between the digit-dot and the space to prevent this, keeping the original numbering intact in both WhatsApp and the dashboard.
+
+## Bot token API access
+
+To support prefilled variables with agent and team data, the following API endpoints are accessible with bot tokens:
+
+- `GET /api/v1/accounts/:id/agents` — List agents
+- `GET /api/v1/accounts/:id/teams` — List teams
+- `GET /api/v1/accounts/:id/contacts` — List/create/update contacts

--- a/typebot-agentbot/agent-bot-typebot.pt-br.md
+++ b/typebot-agentbot/agent-bot-typebot.pt-br.md
@@ -33,6 +33,8 @@ Enviadas apenas na primeira solicitação de uma sessão:
 - Contato: `contact_name`, `contact_email`, `contact_phone`, `contact_id`, `contact_labels`, `contact_attributes`, `contact_custom_attribute_<key>`
 - Conversa: `conversation_labels`, `conversation_id`, `conversation_display_id`, `conversation_attributes`, `custom_attribute_<key>`
 - Conta: `account_id`
+- Agentes: `agents_json` (array JSON com id, name, availability_status), `agents_formatted` (lista numerada com emoji de disponibilidade, ex: `1. 🟢 João`)
+- Equipes: `teams_json` (array JSON com id e name), `teams_formatted` (lista numerada, ex: `1. Vendas`)
 
 Os valores de `<key>` são sanitizados para snake_case em minúsculas.
 
@@ -58,3 +60,71 @@ Os valores de `<key>` são sanitizados para snake_case em minúsculas.
 - Garanta que `public_name` corresponda ao slug público publicado no Typebot e que `api_token` esteja definido para bots privados.
 - Para gatilhos por palavra-chave, confirme se tanto `trigger_operator` quanto `trigger_value` estão configurados.
 - Se as respostas pararem no meio do fluxo, verifique `additional_attributes.typebot` na conversa em busca de um `session_id` antigo e considere usar a palavra-chave de finalização ou reabrir/fechar a conversa para resetar.
+
+## MEGA_CMD — Interceptação local de comandos
+
+Como um servidor Typebot externo geralmente não consegue fazer chamadas HTTP de volta para a instância do Mega (firewalls, isolamento de rede Docker, etc.), o MEGA_CMD oferece uma forma de executar ações localmente sem webhooks.
+
+### Como funciona
+
+1. No seu fluxo Typebot, inclua um **balão de texto** com um marcador de comando: `[MEGA_CMD:ação:valor]`
+2. Quando o Mega recebe a resposta do Typebot, ele intercepta o marcador **antes** de enviar a mensagem para a conversa.
+3. O comando é executado no lado do servidor (ex: atribuir um agente ou equipe).
+4. O marcador é removido do texto — o usuário final nunca o vê.
+
+### Ações suportadas
+
+| Ação | Valor | Exemplo | Descrição |
+|------|-------|---------|-----------|
+| `assign_agent` | ID do agente | `[MEGA_CMD:assign_agent:5]` | Atribui o agente com id 5 à conversa |
+| `assign_team` | ID da equipe | `[MEGA_CMD:assign_team:3]` | Atribui a equipe com id 3 à conversa |
+
+### Exemplo em um fluxo Typebot
+
+Um balão de texto no Typebot pode conter:
+
+```text
+Obrigado! Você será conectado à nossa equipe de suporte em breve.
+[MEGA_CMD:assign_team:3]
+```
+
+O usuário vê apenas: *"Obrigado! Você será conectado à nossa equipe de suporte em breve."*
+
+O comando pode ser combinado com texto regular. Múltiplos comandos na mesma mensagem também são suportados.
+
+## Placeholders de listas — Menus numerados dinâmicos
+
+A interpolação de variáveis do Typebot pode ser pouco confiável ao construir listas numeradas para WhatsApp (não suporta botões). O Mega fornece **placeholders de listas** no lado do servidor que são substituídos por listas numeradas geradas dinamicamente antes da mensagem ser entregue.
+
+### Placeholders disponíveis
+
+| Placeholder | Substituído por |
+|-------------|----------------|
+| `[TEAMS_LIST]` | Lista numerada de todas as equipes da conta, ordenadas por nome. Exemplo: `1. Vendas\n2. Suporte` |
+| `[AGENTS_LIST]` | Lista numerada de agentes online com emoji de disponibilidade. Exemplo: `1. 🟢 João\n2. 🟢 Maria` |
+
+### Como usar em um fluxo Typebot
+
+Em um balão de texto, inclua o placeholder:
+
+```text
+Por favor selecione uma equipe:
+
+[TEAMS_LIST]
+
+0. ⬅️ Voltar ao menu
+```
+
+O Mega substitui `[TEAMS_LIST]` pela lista numerada real antes de entregar a mensagem.
+
+### Escape de listas Markdown
+
+Listas numeradas (ex: `1. Vendas`) normalmente seriam parseadas como listas ordenadas pelo renderizador Markdown do dashboard, o que renumera os itens (ex: convertendo `0.` em `3.`). O Mega insere um espaço de largura zero (U+200B) entre o dígito-ponto e o espaço para evitar isso, mantendo a numeração original tanto no WhatsApp quanto no dashboard.
+
+## Acesso à API com token de bot
+
+Para suportar as variáveis preenchidas com dados de agentes e equipes, os seguintes endpoints da API são acessíveis com tokens de bot:
+
+- `GET /api/v1/accounts/:id/agents` — Listar agentes
+- `GET /api/v1/accounts/:id/teams` — Listar equipes
+- `GET /api/v1/accounts/:id/contacts` — Listar/criar/atualizar contatos

--- a/typebot-agentbot/example/typebot-agent-assignment-flow.json
+++ b/typebot-agentbot/example/typebot-agent-assignment-flow.json
@@ -1,0 +1,1081 @@
+{
+    "version": "6.1",
+    "id": "mega-agent-assignment-flow-v3",
+    "name": "Mega - Asignación de Agentes y Equipos v3",
+    "events": [
+        {
+            "id": "evt_start",
+            "outgoingEdgeId": "edge_start_to_config",
+            "graphCoordinates": {
+                "x": 0,
+                "y": 0
+            },
+            "type": "start"
+        }
+    ],
+    "groups": [
+        {
+            "id": "grp_config",
+            "title": "Configuración",
+            "graphCoordinates": {
+                "x": 50,
+                "y": 100
+            },
+            "blocks": [
+                {
+                    "id": "blk_parse_agents",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_agents_parsed",
+                        "expressionToEvaluate": "try {\n  let raw = {{agents_json}}\n  if (typeof raw === 'string') raw = JSON.parse(raw)\n  if (!Array.isArray(raw)) return '[]'\n  return JSON.stringify(raw)\n} catch(e) { return '[]' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                },
+                {
+                    "id": "blk_parse_teams",
+                    "outgoingEdgeId": "edge_config_to_welcome",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_teams_parsed",
+                        "expressionToEvaluate": "try {\n  let raw = {{teams_json}}\n  if (typeof raw === 'string') raw = JSON.parse(raw)\n  if (!Array.isArray(raw)) return '[]'\n  return JSON.stringify(raw)\n} catch(e) { return '[]' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_welcome",
+            "title": "Menú Principal",
+            "graphCoordinates": {
+                "x": 400,
+                "y": 100
+            },
+            "blocks": [
+                {
+                    "id": "blk_welcome_text",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "Hola 👋 "
+                                    },
+                                    {
+                                        "bold": true,
+                                        "text": "{{contact_name}}"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "¿Cómo te gustaría que te atendamos?"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "1. 🤖 Agente disponible (automático)"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "2. 👤 Elegir un agente"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "3. 👥 Elegir un equipo"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "blk_welcome_input",
+                    "outgoingEdgeId": "edge_welcome_to_menu_cond",
+                    "type": "text input",
+                    "options": {
+                        "variableId": "var_user_choice",
+                        "labels": {
+                            "placeholder": "Escribe 1, 2 o 3"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_menu_condition",
+            "title": "Condición del Menú",
+            "graphCoordinates": {
+                "x": 800,
+                "y": 100
+            },
+            "blocks": [
+                {
+                    "id": "blk_menu_cond",
+                    "outgoingEdgeId": "edge_menu_default_to_welcome",
+                    "type": "Condition",
+                    "items": [
+                        {
+                            "id": "item_cond_auto",
+                            "outgoingEdgeId": "edge_cond_to_auto",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_auto",
+                                        "variableId": "var_user_choice",
+                                        "comparisonOperator": "Equal to",
+                                        "value": "1"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "item_cond_agent",
+                            "outgoingEdgeId": "edge_cond_to_agent",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_agent",
+                                        "variableId": "var_user_choice",
+                                        "comparisonOperator": "Equal to",
+                                        "value": "2"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "id": "item_cond_team",
+                            "outgoingEdgeId": "edge_cond_to_team",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_team",
+                                        "variableId": "var_user_choice",
+                                        "comparisonOperator": "Equal to",
+                                        "value": "3"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "id": "grp_auto_assign",
+            "title": "Auto-asignar Agente",
+            "graphCoordinates": {
+                "x": 1200,
+                "y": -200
+            },
+            "blocks": [
+                {
+                    "id": "blk_auto_pick_id",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_selected_agent_id",
+                        "expressionToEvaluate": "try {\n  const agents = JSON.parse({{agents_parsed}})\n  if (!agents.length) return ''\n  const online = agents.find(a => a.availability_status === 'online')\n  if (online) return String(online.id)\n  const busy = agents.find(a => a.availability_status === 'busy')\n  if (busy) return String(busy.id)\n  return String(agents[0].id)\n} catch(e) { return '' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                },
+                {
+                    "id": "blk_auto_pick_name",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_selected_agent_name",
+                        "expressionToEvaluate": "try {\n  const agents = JSON.parse({{agents_parsed}})\n  const selId = String({{selected_agent_id}})\n  const found = agents.find(a => String(a.id) === selId)\n  return found ? found.name : 'un agente'\n} catch(e) { return 'un agente' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                },
+                {
+                    "id": "blk_auto_check",
+                    "type": "Condition",
+                    "items": [
+                        {
+                            "id": "item_auto_found",
+                            "outgoingEdgeId": "edge_auto_to_confirm",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_auto_found",
+                                        "variableId": "var_selected_agent_id",
+                                        "comparisonOperator": "Is set"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "outgoingEdgeId": "edge_auto_to_no_agents"
+                }
+            ]
+        },
+        {
+            "id": "grp_auto_confirm",
+            "title": "Confirmar Auto-asignación",
+            "graphCoordinates": {
+                "x": 1600,
+                "y": -200
+            },
+            "blocks": [
+                {
+                    "id": "blk_auto_confirm_text",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "✅ Te conectamos con "
+                                    },
+                                    {
+                                        "bold": true,
+                                        "text": "{{selected_agent_name}}"
+                                    },
+                                    {
+                                        "text": ". Te atenderá en breve 🙌"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "[MEGA_CMD:assign_agent:{{selected_agent_id}}]"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_auto_no_agents",
+            "title": "Sin Agentes Disponibles",
+            "graphCoordinates": {
+                "x": 1600,
+                "y": -400
+            },
+            "blocks": [
+                {
+                    "id": "blk_no_agents_msg",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "😔 No hay agentes disponibles en este momento."
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "Tu conversación será abierta y te atenderán lo antes posible. 🙌"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_choose_agent",
+            "title": "Elegir Agente",
+            "graphCoordinates": {
+                "x": 1200,
+                "y": 100
+            },
+            "blocks": [
+                {
+                    "id": "blk_format_agents",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_agents_list_text",
+                        "expressionToEvaluate": "{{agents_formatted}}",
+                        "type": "Custom",
+                        "isCode": false
+                    }
+                },
+                {
+                    "id": "blk_show_agents",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "bold": true,
+                                        "text": "👤 Elige un agente:"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "🟢 Online  🟡 Ocupado  ⚪ Offline"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "[AGENTS_LIST]"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "0. ⬅️ Volver al menú"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "blk_agent_input",
+                    "outgoingEdgeId": "edge_agent_input_to_validate",
+                    "type": "text input",
+                    "options": {
+                        "variableId": "var_agent_pick_number",
+                        "labels": {
+                            "placeholder": "Escribe el número del agente o 0 para volver"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_agent_validate",
+            "title": "Validar Agente",
+            "graphCoordinates": {
+                "x": 1400,
+                "y": 0
+            },
+            "blocks": [
+                {
+                    "id": "blk_agent_back_check",
+                    "type": "Condition",
+                    "items": [
+                        {
+                            "id": "item_agent_back",
+                            "outgoingEdgeId": "edge_agent_back_to_welcome",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_agent_back",
+                                        "variableId": "var_agent_pick_number",
+                                        "comparisonOperator": "Equal to",
+                                        "value": "0"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "outgoingEdgeId": "edge_agent_to_map"
+                }
+            ]
+        },
+        {
+            "id": "grp_agent_map",
+            "title": "Mapear Agente",
+            "graphCoordinates": {
+                "x": 1600,
+                "y": 100
+            },
+            "blocks": [
+                {
+                    "id": "blk_map_agent_id",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_selected_agent_id",
+                        "expressionToEvaluate": "try {\n  const agents = JSON.parse({{agents_parsed}})\n  const pick = parseInt({{agent_pick_number}})\n  if (!agents.length || isNaN(pick) || pick < 1 || pick > agents.length) return ''\n  return String(agents[pick - 1].id)\n} catch(e) { return '' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                },
+                {
+                    "id": "blk_map_agent_name",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_selected_agent_name",
+                        "expressionToEvaluate": "try {\n  const agents = JSON.parse({{agents_parsed}})\n  const pick = parseInt({{agent_pick_number}})\n  if (!agents.length || isNaN(pick) || pick < 1 || pick > agents.length) return ''\n  return agents[pick - 1].name\n} catch(e) { return '' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                },
+                {
+                    "id": "blk_agent_valid_check",
+                    "type": "Condition",
+                    "items": [
+                        {
+                            "id": "item_agent_valid",
+                            "outgoingEdgeId": "edge_agent_to_confirm",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_agent_valid",
+                                        "variableId": "var_selected_agent_id",
+                                        "comparisonOperator": "Is set"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "outgoingEdgeId": "edge_agent_to_invalid"
+                }
+            ]
+        },
+        {
+            "id": "grp_agent_invalid",
+            "title": "Agente Inválido",
+            "graphCoordinates": {
+                "x": 1600,
+                "y": -50
+            },
+            "blocks": [
+                {
+                    "id": "blk_agent_invalid_msg",
+                    "outgoingEdgeId": "edge_agent_invalid_to_choose",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "⚠️ Número inválido. Por favor, elige un número de la lista."
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_agent_confirm",
+            "title": "Confirmar Agente",
+            "graphCoordinates": {
+                "x": 2000,
+                "y": 100
+            },
+            "blocks": [
+                {
+                    "id": "blk_agent_confirm_text",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "✅ Te conectamos con "
+                                    },
+                                    {
+                                        "bold": true,
+                                        "text": "{{selected_agent_name}}"
+                                    },
+                                    {
+                                        "text": ". Te atenderá en breve 🙌"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "[MEGA_CMD:assign_agent:{{selected_agent_id}}]"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_choose_team",
+            "title": "Elegir Equipo",
+            "graphCoordinates": {
+                "x": 1200,
+                "y": 400
+            },
+            "blocks": [
+                {
+                    "id": "blk_format_teams",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_teams_list_text",
+                        "expressionToEvaluate": "{{teams_formatted}}",
+                        "type": "Custom",
+                        "isCode": false
+                    }
+                },
+                {
+                    "id": "blk_show_teams",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "bold": true,
+                                        "text": "👥 Elige un equipo:"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "[TEAMS_LIST]"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": ""
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "0. ⬅️ Volver al menú"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "id": "blk_team_input",
+                    "outgoingEdgeId": "edge_team_input_to_validate",
+                    "type": "text input",
+                    "options": {
+                        "variableId": "var_team_pick_number",
+                        "labels": {
+                            "placeholder": "Escribe el número del equipo o 0 para volver"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_team_validate",
+            "title": "Validar Equipo",
+            "graphCoordinates": {
+                "x": 1400,
+                "y": 500
+            },
+            "blocks": [
+                {
+                    "id": "blk_team_back_check",
+                    "type": "Condition",
+                    "items": [
+                        {
+                            "id": "item_team_back",
+                            "outgoingEdgeId": "edge_team_back_to_welcome",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_team_back",
+                                        "variableId": "var_team_pick_number",
+                                        "comparisonOperator": "Equal to",
+                                        "value": "0"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "outgoingEdgeId": "edge_team_to_map"
+                }
+            ]
+        },
+        {
+            "id": "grp_team_map",
+            "title": "Mapear Equipo",
+            "graphCoordinates": {
+                "x": 1600,
+                "y": 400
+            },
+            "blocks": [
+                {
+                    "id": "blk_map_team_id",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_selected_team_id",
+                        "expressionToEvaluate": "try {\n  const teams = JSON.parse({{teams_parsed}})\n  const pick = parseInt({{team_pick_number}})\n  if (!teams.length || isNaN(pick) || pick < 1 || pick > teams.length) return ''\n  return String(teams[pick - 1].id)\n} catch(e) { return '' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                },
+                {
+                    "id": "blk_map_team_name",
+                    "type": "Set variable",
+                    "options": {
+                        "variableId": "var_selected_team_name",
+                        "expressionToEvaluate": "try {\n  const teams = JSON.parse({{teams_parsed}})\n  const pick = parseInt({{team_pick_number}})\n  if (!teams.length || isNaN(pick) || pick < 1 || pick > teams.length) return ''\n  return teams[pick - 1].name\n} catch(e) { return '' }",
+                        "type": "Custom",
+                        "isCode": true
+                    }
+                },
+                {
+                    "id": "blk_team_valid_check",
+                    "type": "Condition",
+                    "items": [
+                        {
+                            "id": "item_team_valid",
+                            "outgoingEdgeId": "edge_team_to_confirm",
+                            "content": {
+                                "comparisons": [
+                                    {
+                                        "id": "cmp_team_valid",
+                                        "variableId": "var_selected_team_id",
+                                        "comparisonOperator": "Is set"
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "outgoingEdgeId": "edge_team_to_invalid"
+                }
+            ]
+        },
+        {
+            "id": "grp_team_invalid",
+            "title": "Equipo Inválido",
+            "graphCoordinates": {
+                "x": 1600,
+                "y": 550
+            },
+            "blocks": [
+                {
+                    "id": "blk_team_invalid_msg",
+                    "outgoingEdgeId": "edge_team_invalid_to_choose",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "⚠️ Número inválido. Por favor, elige un número de la lista."
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "id": "grp_team_confirm",
+            "title": "Confirmar Equipo",
+            "graphCoordinates": {
+                "x": 2000,
+                "y": 400
+            },
+            "blocks": [
+                {
+                    "id": "blk_team_confirm_text",
+                    "type": "text",
+                    "content": {
+                        "richText": [
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "✅ Te conectamos con el equipo "
+                                    },
+                                    {
+                                        "bold": true,
+                                        "text": "{{selected_team_name}}"
+                                    },
+                                    {
+                                        "text": ". Te atenderán en breve 🙌"
+                                    }
+                                ]
+                            },
+                            {
+                                "type": "p",
+                                "children": [
+                                    {
+                                        "text": "[MEGA_CMD:assign_team:{{selected_team_id}}]"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "edges": [
+        {
+            "id": "edge_start_to_config",
+            "from": {
+                "eventId": "evt_start"
+            },
+            "to": {
+                "groupId": "grp_config"
+            }
+        },
+        {
+            "id": "edge_config_to_welcome",
+            "from": {
+                "blockId": "blk_parse_teams"
+            },
+            "to": {
+                "groupId": "grp_welcome"
+            }
+        },
+        {
+            "id": "edge_welcome_to_menu_cond",
+            "from": {
+                "blockId": "blk_welcome_input"
+            },
+            "to": {
+                "groupId": "grp_menu_condition"
+            }
+        },
+        {
+            "id": "edge_cond_to_auto",
+            "from": {
+                "blockId": "blk_menu_cond",
+                "itemId": "item_cond_auto"
+            },
+            "to": {
+                "groupId": "grp_auto_assign"
+            }
+        },
+        {
+            "id": "edge_cond_to_agent",
+            "from": {
+                "blockId": "blk_menu_cond",
+                "itemId": "item_cond_agent"
+            },
+            "to": {
+                "groupId": "grp_choose_agent"
+            }
+        },
+        {
+            "id": "edge_cond_to_team",
+            "from": {
+                "blockId": "blk_menu_cond",
+                "itemId": "item_cond_team"
+            },
+            "to": {
+                "groupId": "grp_choose_team"
+            }
+        },
+        {
+            "id": "edge_menu_default_to_welcome",
+            "from": {
+                "blockId": "blk_menu_cond"
+            },
+            "to": {
+                "groupId": "grp_welcome"
+            }
+        },
+        {
+            "id": "edge_auto_to_confirm",
+            "from": {
+                "blockId": "blk_auto_check",
+                "itemId": "item_auto_found"
+            },
+            "to": {
+                "groupId": "grp_auto_confirm"
+            }
+        },
+        {
+            "id": "edge_auto_to_no_agents",
+            "from": {
+                "blockId": "blk_auto_check"
+            },
+            "to": {
+                "groupId": "grp_auto_no_agents"
+            }
+        },
+        {
+            "id": "edge_agent_input_to_validate",
+            "from": {
+                "blockId": "blk_agent_input"
+            },
+            "to": {
+                "groupId": "grp_agent_validate"
+            }
+        },
+        {
+            "id": "edge_agent_back_to_welcome",
+            "from": {
+                "blockId": "blk_agent_back_check",
+                "itemId": "item_agent_back"
+            },
+            "to": {
+                "groupId": "grp_welcome"
+            }
+        },
+        {
+            "id": "edge_agent_to_map",
+            "from": {
+                "blockId": "blk_agent_back_check"
+            },
+            "to": {
+                "groupId": "grp_agent_map"
+            }
+        },
+        {
+            "id": "edge_agent_to_confirm",
+            "from": {
+                "blockId": "blk_agent_valid_check",
+                "itemId": "item_agent_valid"
+            },
+            "to": {
+                "groupId": "grp_agent_confirm"
+            }
+        },
+        {
+            "id": "edge_agent_to_invalid",
+            "from": {
+                "blockId": "blk_agent_valid_check"
+            },
+            "to": {
+                "groupId": "grp_agent_invalid"
+            }
+        },
+        {
+            "id": "edge_agent_invalid_to_choose",
+            "from": {
+                "blockId": "blk_agent_invalid_msg"
+            },
+            "to": {
+                "groupId": "grp_choose_agent"
+            }
+        },
+        {
+            "id": "edge_team_input_to_validate",
+            "from": {
+                "blockId": "blk_team_input"
+            },
+            "to": {
+                "groupId": "grp_team_validate"
+            }
+        },
+        {
+            "id": "edge_team_back_to_welcome",
+            "from": {
+                "blockId": "blk_team_back_check",
+                "itemId": "item_team_back"
+            },
+            "to": {
+                "groupId": "grp_welcome"
+            }
+        },
+        {
+            "id": "edge_team_to_map",
+            "from": {
+                "blockId": "blk_team_back_check"
+            },
+            "to": {
+                "groupId": "grp_team_map"
+            }
+        },
+        {
+            "id": "edge_team_to_confirm",
+            "from": {
+                "blockId": "blk_team_valid_check",
+                "itemId": "item_team_valid"
+            },
+            "to": {
+                "groupId": "grp_team_confirm"
+            }
+        },
+        {
+            "id": "edge_team_to_invalid",
+            "from": {
+                "blockId": "blk_team_valid_check"
+            },
+            "to": {
+                "groupId": "grp_team_invalid"
+            }
+        },
+        {
+            "id": "edge_team_invalid_to_choose",
+            "from": {
+                "blockId": "blk_team_invalid_msg"
+            },
+            "to": {
+                "groupId": "grp_choose_team"
+            }
+        }
+    ],
+    "variables": [
+        {
+            "id": "var_contact_name",
+            "name": "contact_name"
+        },
+        {
+            "id": "var_agents_json",
+            "name": "agents_json"
+        },
+        {
+            "id": "var_teams_json",
+            "name": "teams_json"
+        },
+        {
+            "id": "var_agents_parsed",
+            "name": "agents_parsed"
+        },
+        {
+            "id": "var_teams_parsed",
+            "name": "teams_parsed"
+        },
+        {
+            "id": "var_agents_list_text",
+            "name": "agents_list_text"
+        },
+        {
+            "id": "var_teams_list_text",
+            "name": "teams_list_text"
+        },
+        {
+            "id": "var_user_choice",
+            "name": "user_choice"
+        },
+        {
+            "id": "var_agent_pick_number",
+            "name": "agent_pick_number"
+        },
+        {
+            "id": "var_team_pick_number",
+            "name": "team_pick_number"
+        },
+        {
+            "id": "var_selected_agent_id",
+            "name": "selected_agent_id"
+        },
+        {
+            "id": "var_selected_agent_name",
+            "name": "selected_agent_name"
+        },
+        {
+            "id": "var_selected_team_id",
+            "name": "selected_team_id"
+        },
+        {
+            "id": "var_selected_team_name",
+            "name": "selected_team_name"
+        },
+        {
+            "id": "var_agents_formatted",
+            "name": "agents_formatted",
+            "isSessionVariable": true
+        },
+        {
+            "id": "var_teams_formatted",
+            "name": "teams_formatted",
+            "isSessionVariable": true
+        }
+    ],
+    "theme": {},
+    "selectedThemeTemplateId": null,
+    "settings": {
+        "general": {
+            "isBrandingEnabled": false
+        }
+    },
+    "createdAt": "2025-03-19T00:00:00.000Z",
+    "updatedAt": "2025-03-19T00:00:00.000Z",
+    "icon": null,
+    "folderId": null,
+    "publicId": "mega-agent-assignment-v3",
+    "customDomain": null,
+    "resultsTablePreferences": null,
+    "isArchived": false,
+    "isClosed": false,
+    "whatsAppCredentialsId": null,
+    "riskLevel": null
+}


### PR DESCRIPTION
## Resumen

Actualiza la documentación de Typebot Agent Bot con las nuevas funcionalidades implementadas para asignación de agentes y equipos vía flujos de Typebot.

## Cambios

### Documentación actualizada (en, es, pt-br)

**MEGA_CMD — Intercepción local de comandos**
- Sistema para ejecutar acciones del servidor (asignar agente/equipo) directamente desde flujos de Typebot sin necesidad de webhooks
- Patrón: `[MEGA_CMD:acción:valor]` en burbujas de texto
- Acciones soportadas: `assign_agent`, `assign_team`

**Placeholders de listas — Menús numerados dinámicos**
- `[TEAMS_LIST]` → lista numerada de equipos
- `[AGENTS_LIST]` → lista numerada de agentes online con emoji de disponibilidad
- Reemplazo del lado del servidor para WhatsApp (donde los botones no están soportados)

**Escape de listas Markdown**
- Documentación sobre la inserción de zero-width space (U+200B) para prevenir que el renderizador Markdown del dashboard renumere ítems

**Acceso API con token de bot**
- Endpoints accesibles: agents, teams, contacts

**Variables prellenadas actualizadas**
- Nuevas variables: `agents_json`, `teams_json`, `agents_formatted`, `teams_formatted`

### Nuevo ejemplo
- `typebot-agent-assignment-flow.json`: Flujo completo de Typebot v3 con menú de selección de agentes/equipos, navegación atrás, y cambio automático de estado a open

## Archivos modificados
- `typebot-agentbot/agent-bot-typebot.md` (English)
- `typebot-agentbot/agent-bot-typebot.es.md` (Español)
- `typebot-agentbot/agent-bot-typebot.pt-br.md` (Português)
- `typebot-agentbot/example/typebot-agent-assignment-flow.json` (nuevo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation with new agent and team session variables (JSON and formatted variants)
  * Added MEGA_CMD syntax documentation for local command interception with agent/team assignment support
  * Documented dynamic placeholders for generating agent and team numbered menus
  * Added example Typebot workflow demonstrating complete agent/team assignment flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->