### PR TITLE
docs(agents): add feature documentation maintenance rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Stack Development Guidelines
+
+## Features Documentation Maintenance
+
+- Whenever a new feature is added, or an existing feature changes behavior/scope, update feature documentation in the same implementation cycle.
+- Keep both documentation layers in sync under `Features/`:
+  - Commercial/presentation: `features.es.md`, `features.en.md`, `features.pt_BR.md`
+  - Technical/detail: `features-technical.es.md`, `features-technical.en.md`, `features-technical.pt_BR.md`
+- While root-level legacy feature files in `Features/` still exist, keep them aligned too: `FUNCIONALIDADES_MEGA-ES.md`, `FUNCIONALIDADES_MEGA_EN.md`, `FUNCIONALIDADES_MEGA_PT_BR.md`.
+- Do not close a feature documentation task until ES/EN/PT-BR are all updated and consistent.
+- If structure or ownership changes, update `Features/README.md` in the same change.


### PR DESCRIPTION
## Summary
Add a repository-level AGENTS guide with clear rules to keep feature documentation continuously updated.

## What was added
- New `AGENTS.md` at repository root.
- Policy to update docs whenever a feature is added or an existing feature behavior changes.
- Explicit synchronization requirements for:
  - Commercial docs: `Features/features.es.md`, `Features/features.en.md`, `Features/features.pt_BR.md`
  - Technical docs: `Features/features-technical.es.md`, `Features/features-technical.en.md`, `Features/features-technical.pt_BR.md`
- Legacy alignment rule while old files remain:
  - `Features/FUNCIONALIDADES_MEGA-ES.md`
  - `Features/FUNCIONALIDADES_MEGA_EN.md`
  - `Features/FUNCIONALIDADES_MEGA_PT_BR.md`
- Requirement to update `Features/README.md` when structure/ownership changes.

## Why
This prevents missing feature updates in documentation and keeps all language/layer variants consistent over time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established formal guidelines for feature documentation updates, ensuring synchronized maintenance across multiple languages (English, Spanish, Portuguese-Brazilian) and consistent alignment with feature implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->