### PR TITLE
chore: update chatwoot image version to v4.20.0

### DIFF
--- a/mega-docker/mega--sidekiq-split.yml
+++ b/mega-docker/mega--sidekiq-split.yml
@@ -84,7 +84,7 @@ x-variables:
 
 services:
   mega_app:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec rails s -p 3000 -b 0.0.0.0
     entrypoint: docker/entrypoints/rails.sh
     restart: always
@@ -147,7 +147,7 @@ services:
   # EventDispatcherJob queda aislado en el worker events.
   ##############################################################
   mega_sidekiq_critical:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec sidekiq -q critical -q high -q default -c 15
     restart: always
     networks:
@@ -177,7 +177,7 @@ services:
   # critical para no bloquear el realtime del UI.
   ##############################################################
   mega_sidekiq_events:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec sidekiq -q events -c 10
     restart: always
     networks:
@@ -208,7 +208,7 @@ services:
   # saturar DB/Redis durante sincronizaciones grandes.
   ##############################################################
   mega_sidekiq_whatsapp_history:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec sidekiq -q whatsapp_history_sync -c 2
     restart: always
     networks:
@@ -238,7 +238,7 @@ services:
   # mensajes programados y tareas de prioridad media.
   ##############################################################
   mega_sidekiq_medium:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec sidekiq -q medium -q mailers -q action_mailbox_routing -q scheduled_messages -c 10
     restart: always
     networks:
@@ -271,7 +271,7 @@ services:
   # de mailbox. Toleran mayor latencia.
   ##############################################################
   mega_sidekiq_low:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec sidekiq -q low -q scheduled_jobs -q deferred -q purgable -q housekeeping -q async_database_migration -q bulk_reindex_low -q active_storage_analysis -q active_storage_purge -q action_mailbox_incineration -c 10
     restart: always
     networks:

--- a/mega-docker/mega-orion.yml
+++ b/mega-docker/mega-orion.yml
@@ -3,7 +3,7 @@ services:
   ## --------------------------- ORION --------------------------- ##
 
   chatwoot_app:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec rails s -p 3000 -b 0.0.0.0
 
     volumes:
@@ -121,7 +121,7 @@ services:
   ## --------------------------- ORION --------------------------- ##
 
   chatwoot_sidekiq:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec sidekiq -C config/sidekiq.yml
 
     volumes:

--- a/mega-docker/mega-sidekiq-split.yml
+++ b/mega-docker/mega-sidekiq-split.yml
@@ -19,7 +19,7 @@ services:
 ## --------------------------- CHATWOOT APP --------------------------- ##
 
   chatwoot_app:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec rails s -p 3000 -b 0.0.0.0
 
     volumes:
@@ -122,7 +122,7 @@ services:
 ## ------------------------------------------------------------------------------- ##
 
   chatwoot_sidekiq_critical:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec sidekiq -q critical -q high -q default -c 15
 
     volumes:
@@ -215,7 +215,7 @@ services:
 ## ------------------------------------------------------------------------------- ##
 
   chatwoot_sidekiq_events:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec sidekiq -q events -c 10
 
     volumes:
@@ -308,7 +308,7 @@ services:
 ## ------------------------------------------------------------------------------- ##
 
   chatwoot_sidekiq_whatsapp_history:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec sidekiq -q whatsapp_history_sync -c 2
 
     volumes:
@@ -401,7 +401,7 @@ services:
 ## ------------------------------------------------------------------------------- ##
 
   chatwoot_sidekiq_medium:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec sidekiq -q medium -q mailers -q action_mailbox_routing -q scheduled_messages -c 10
 
     volumes:
@@ -494,7 +494,7 @@ services:
 ## ------------------------------------------------------------------------------- ##
 
   chatwoot_sidekiq_low:
-    image: sendingtk/chatwoot:v4.19.0 ## Versão do Chatwoot
+    image: sendingtk/chatwoot:v4.20.0 ## Versão do Chatwoot
     command: bundle exec sidekiq -q low -q scheduled_jobs -q deferred -q purgable -q housekeeping -q async_database_migration -q bulk_reindex_low -q active_storage_analysis -q active_storage_purge -q action_mailbox_incineration -c 10
 
     volumes:

--- a/mega-docker/mega-yml
+++ b/mega-docker/mega-yml
@@ -72,7 +72,7 @@ x-variables: &default_env
   SSO: "false"
 services:
   mega_app:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec rails s -p 3000 -b 0.0.0.0
     entrypoint: docker/entrypoints/rails.sh
     restart: always
@@ -129,7 +129,7 @@ services:
         - traefik.http.middlewares.sslheader.headers.customrequestheaders.X-Forwarded-Proto=https
 
   mega_sidekiq:
-    image: sendingtk/chatwoot:v4.19.0
+    image: sendingtk/chatwoot:v4.20.0
     command: bundle exec sidekiq -C config/sidekiq.yml
     restart: always
     networks:


### PR DESCRIPTION
Update the Chatwoot docker image version from v4.19.0 to v4.20.0 across all service configurations, including the application and various Sidekiq worker splits in the following files:
- mega--sidekiq-split.yml
- mega-orion.yml
- mega-sidekiq-split.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the Chatwoot application and background worker services to version 4.20.0.
  - Applied the update consistently across standard, split-worker, and Orion deployments.
  - Existing service settings and deployment configurations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->